### PR TITLE
spec: fix typos and add atomicity requirement for registration

### DIFF
--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -877,6 +877,10 @@ Registers a new agent through a host.
 | `login_hint` | string | No | User identifier hint for approval methods that benefit from the server already knowing who should approve (for example CIBA). The server MAY ignore it, validate it against its own rules, or reject it if the format is unsupported. |
 | `binding_message` | string | No | Short message shown to the approver when the selected approval method supports it. Intended to help the user confirm what they are approving. The server MAY ignore it or display a server-generated message instead. |
 
+**Atomicity:**
+
+When the host is unknown and the server creates a new host record as part of agent registration (§2.8), the host creation and agent creation MUST be atomic. If agent creation fails for any reason (e.g. `invalid_capabilities`, `unsupported_mode`), the server MUST NOT persist the host record. This prevents orphaned host records that could alter the behavior of subsequent registration attempts — for example, a failed first attempt leaving a host record that causes the server to treat the next attempt as a known host rather than a first-time registration.
+
 **Idempotency and retry semantics:**
 
 Registration is keyed by the host identity plus the agent public key carried in the host JWT.

--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -44,7 +44,7 @@ Existing auth models fail because they provide at most one of these properties. 
 
 ### 1.3 Solution
 
-Agent Auth makes the runtime agent a first-class principal with both properties. Instead of borrowing a user's session or a shared application token, each agent is registered with its own identity, granted capabilities, and lifecycle. Every agent is created under a persistent identity called a **host** (§2.7), which the **client**(§6) registers with each server it connects to.
+Agent Auth makes the runtime agent a first-class principal with both properties. Instead of borrowing a user's session or a shared application token, each agent is registered with its own identity, granted capabilities, and lifecycle. Every agent is created under a persistent identity called a **host** (§2.7), which the **client** (§6) registers with each server it connects to.
 
 When the agent needs to act, it authenticates with short-lived signed JWTs tied to that registration. This gives the server something existing auth models are missing: a durable way to identify which specific agent is acting, which host it belongs to, what mode it runs in, what capabilities it holds, and how to suspend, expire, or revoke it without affecting everything else.
 
@@ -111,8 +111,8 @@ Each agent is created under a host. This lets the server reason separately about
                                   +----------->|     Owner     |
                                   |<-----------| Approval      |
                                   |            |    (User)     |
-                                 |            +---------------+
-                                 |
+                                  |            +---------------+
+                                  |
      +-------+          +--------+            +---------------+
      |       |-(F)----->|        |-(G)------->| Authorization |
      | Agent | execute  | Client | POST       |    Server     |


### PR DESCRIPTION
## Summary
- Fix missing space in §1.3: `**client**(§6)` → `**client** (§6)`
- Fix misaligned pipe character in Figure 1 (§1.7)
- Add **Atomicity** requirement to §5.3 (Agent Registration): when a server dynamically creates a host during agent registration, host creation and agent creation MUST be atomic — if agent creation fails (e.g. `invalid_capabilities`, `unsupported_mode`), the host record MUST NOT persist. This prevents orphaned host records from altering the behavior of subsequent registration attempts.

## Test plan
- [ ] Verify the spec renders correctly on the site
- [ ] Review the atomicity language for clarity and correctness