### PR TITLE
spec: security hardening and JWT identity model

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -580,6 +580,7 @@ Agents authenticate by signing short-lived JWTs per [RFC 7519](https://datatrack
 
 ```json
 {
+  "iss": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
   "sub": "agt_k7x9m2",
   "aud": "https://api.example.com",
   "iat": 1710000000,
@@ -1586,6 +1587,8 @@ Because agent JWTs are short-lived (SHOULD be ≤60 seconds per §8.2), the clie
 
 For streaming capabilities, the server returns a `200` response with `Content-Type: text/event-stream` and streams Server-Sent Events. The client SHOULD expose the stream to the agent when the transport supports it.
 
+**Streaming and JWT expiry.** Unlike polling, an SSE stream can outlive the agent JWT that initiated it. The server authenticates the agent at connection time (the initial `POST /agent/execute` request carries the JWT). Once the stream is established, the server SHOULD enforce a maximum stream duration aligned with its security requirements (e.g. 5 minutes, 1 hour). Servers that require continuous authentication SHOULD terminate the stream when the initiating JWT's `exp` time is reached, requiring the client to reconnect with a fresh JWT. Servers that prioritize long-running streams over continuous auth MAY allow the stream to continue beyond JWT expiry, but MUST check agent and host revocation status periodically (e.g. every 60 seconds) and terminate the stream if the agent or host has been revoked.
+
 **Constraint enforcement:**
 
 If the agent's grant for the requested capability carries constraints (§2.13), the server MUST validate the supplied arguments against those constraints before executing. If any argument violates a constraint, the server MUST reject the request with `403 constraint_violated`. The error response SHOULD include a violations array listing which constraints were violated:
@@ -2162,7 +2165,7 @@ Executes a granted capability through the server's execute endpoint (§5.11). Th
 
 **Behavior:**
 
-1. Sign an agent JWT scoped to this capability
+1. Sign an agent JWT scoped to this capability with `aud` set to the target server's `issuer` URL. See §8.18 for cross-server `aud` enforcement requirements.
 2. Call `POST /capability/execute` (§5.11) with the agent JWT, `capability`, and `arguments`
 3. Return the result to the agent
 4. For async responses (`status: "pending"`), poll the `status_url` until completion and return the final result
@@ -2335,6 +2338,8 @@ Because `iss` is the JWK thumbprint of the signing key, JWKS key rotation change
 
 Hosts that register across many servers SHOULD prefer JWKS-based registration, since key rotation propagates automatically without the client needing to contact each server individually.
 
+**Key delivery mode is fixed at registration.** A host registered with `host_public_key` (inline) MUST NOT later present `host_jwks_url`, and vice versa. Servers MUST reject host JWTs where the key delivery mode differs from the one used at registration. This prevents an attacker who compromises a JWKS endpoint from pivoting to inline key registration to maintain persistent access after the JWKS is remediated. If a host needs to switch modes, it MUST re-register as a new host.
+
 ### 8.8 Agent Key Compromise
 
 If an agent's private key is leaked, anyone holding it can impersonate that agent. This is inherent to any keypair-based system (same as a leaked SSH key or OAuth token). However, unlike bearer tokens, the agent's private key never traverses the wire — it can only leak from the client's local storage.
@@ -2347,6 +2352,25 @@ Mitigations:
 
 After registration, the agent authenticates independently with its own keypair — the host is not involved in every request. If binding agent requests to the host is required, implementations can enforce this at the server level.
 
+### 8.8.1 Host Key Compromise
+
+A compromised host key is significantly more damaging than a compromised agent key. The attacker can:
+
+- **Register arbitrary agents** under the host, gaining new capabilities
+- **Revoke the host** (denial of service to all agents under it)
+- **Rotate the host key** via §5.9 (inline-key hosts), locking out the legitimate owner
+- **Impersonate all future host-authenticated operations** — status checks, capability requests, agent management
+
+The inline key rotation endpoint (§5.9) is unusable during a host key compromise because it requires authentication with the current (compromised) key. The attacker can use it; the legitimate owner cannot.
+
+**Response:**
+
+1. **Revoke the host immediately.** The user (or server admin) MUST revoke the host through an out-of-band mechanism (dashboard, admin API, support). Revocation cascades to all agents under the host (§8.5).
+2. **Re-register.** After revocation, the client generates a new host keypair and registers as a new host. This creates a fresh identity with no connection to the compromised one.
+3. **JWKS hosts.** If using JWKS, revoke the compromised key at the JWKS endpoint. The server will pick up the removal on the next cache refresh. However, if the attacker has access to the JWKS endpoint itself, the endpoint is also compromised — treat this as a full host compromise and revoke.
+
+Servers SHOULD provide an authenticated, out-of-band mechanism (e.g. user dashboard) for users to revoke hosts without needing the host's private key. This is the only reliable recovery path for host key compromise.
+
 ### 8.9 Discovery Security
 
 Discovery of arbitrary URLs is a prompt injection vector. A malicious prompt can trick an agent into calling `discover_provider(url: "https://evil.com")`, which returns a fake configuration. The client then sends the host JWT to the attacker's "register" endpoint.
@@ -2358,6 +2382,7 @@ Mitigations:
 - **Proof on host-authenticated registration.** For **discovered servers** (not pre-configured), clients SHOULD use DPoP or an equivalent request-specific proof on host-authenticated registration requests so they cannot be replayed to a different endpoint.
 - **TLS verification.** Clients MUST verify TLS certificates when fetching discovery endpoints.
 - **Registry integrity.** When using registry-based discovery, clients SHOULD verify that the `issuer` in the fetched discovery document matches the `issuer` from the registry result. A mismatch indicates a poisoned registry entry or a man-in-the-middle attack. See §6.11 for registry-side protections.
+- **Algorithm downgrade protection.** See §8.16.
 
 ### 8.10 Approval Gravity
 
@@ -2366,6 +2391,8 @@ User approval is the primary trust boundary in this protocol — for unknown hos
 **Self-attestation during dynamic registration.** When a host registers for the first time, its JWT is self-signed — the public key is carried inside the JWT itself, and the server has never seen this host before. Anyone can create a valid host identity. The server MUST NOT grant any capabilities or trust the host identity until user approval completes. Until approval, the host and agent exist in `pending` state with no granted access. This is the designed trust model: the cryptographic identity is established immediately, but authorization is deferred entirely to the approval flow.
 
 First-time host approval is the highest-risk moment: the server knows nothing about the host beyond a self-signed keypair. Servers SHOULD present the requested capabilities clearly and warn if the host is requesting unusually broad access.
+
+**Display-text safety.** Several protocol fields shown on approval screens are attacker-controlled: `name`, `reason`, `host_name`, and `binding_message` (CIBA). A malicious host could set `host_name` to `"Apple Security Update"` or `reason` to social-engineering text designed to manipulate the user into approving. Servers MUST sanitize these fields before rendering — strip HTML, limit length, and escape special characters. Servers SHOULD warn users when display names resemble well-known brands or services (e.g. homoglyph detection). Servers MUST NOT render these fields as trusted content (no raw HTML, no markdown interpretation, no clickable links).
 
 Capability escalation deserves the same scrutiny. Servers SHOULD NOT auto-approve high-risk capabilities even for linked hosts. Servers MUST calibrate approval requirements to the sensitivity of their capabilities — the protocol provides the mechanism (approval flows, fresh auth, 2FA), but the server decides which to enforce.
 
@@ -2420,6 +2447,19 @@ For discovery-specific protections (allowlists, user confirmation, TLS verificat
 - Servers SHOULD limit the number of keys in a JWKS response (e.g. 20 keys). An attacker-controlled JWKS with many keys forces the server to attempt signature verification against each one.
 - Servers SHOULD cache JWKS responses per [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517) cache headers, with a maximum cache duration (e.g. 24 hours) and a minimum refresh interval (e.g. 5 minutes) to prevent cache-busting attacks.
 
+**Server-returned URL validation.** The protections above cover URLs that clients and servers *fetch from external sources*. Clients MUST also validate URLs that the *server returns* to them — `status_url` (§5.11 async polling), `verification_uri` (§7.1 device authorization), and `notification_url` (§10.8.2 real-time approval). A malicious or compromised server could return URLs that:
+
+- Point to the client's local network (client-side SSRF via `status_url`)
+- Serve phishing pages designed to harvest user credentials (via `verification_uri`)
+- Exfiltrate data via DNS or HTTP requests to attacker-controlled domains
+
+Clients MUST apply the following to server-returned URLs:
+
+- **HTTPS only.** Reject `http://` URLs.
+- **Origin validation.** For `status_url`, the URL MUST share the same origin (scheme + host + port) as the server's `issuer` URL. Reject cross-origin polling URLs. For `verification_uri`, the URL SHOULD match the server's origin or a known authorization domain for that server.
+- **IP filtering.** Clients SHOULD block `status_url` values that resolve to private, loopback, or link-local IP ranges (same filtering as §8.12 server-side fetches, applied client-side).
+- **User visibility.** For `verification_uri` shown to users, the client SHOULD display the full URL so the user can verify the domain before entering credentials.
+
 ### 8.13 Rate Limiting
 
 Servers MUST implement rate limiting. Agents can generate high request volumes — both legitimately and due to bugs or compromised keys.
@@ -2464,6 +2504,34 @@ These are optional enhancements. The base protocol's security model (short-lived
 Capability names are server-defined strings and MUST be treated as opaque identifiers by clients. Because the server defines and controls its own capability namespace, capability name squatting (where an attacker pre-registers a capability name to hijack later requests) is not a protocol-level threat — the server is authoritative over its own names.
 
 However, if a server allows hosts to _suggest_ new capability names during registration (an extension behavior, not defined in this specification), the server MUST validate suggested names against its own namespace and reject conflicts. The risk in this scenario is a confused-deputy attack where a malicious host registers a capability name that collides with a legitimate one.
+
+### 8.16 Discovery Downgrade Attacks
+
+The `algorithms` field in discovery (§5.1) tells clients which key types the server accepts. If an attacker can modify the discovery document in transit (e.g. via a compromised cache or DNS hijack), they could remove strong algorithms and force clients to register with weaker ones.
+
+Mitigations:
+
+- **TLS is the primary defense.** Discovery documents are fetched over HTTPS (§8.9), which protects against in-transit modification. This threat is only relevant if TLS is compromised or if a client accepts discovery documents over an insecure channel.
+- **Clients SHOULD reject unexpected algorithm downgrades.** If a client has previously connected to a server that supported `Ed25519` and a subsequent discovery fetch no longer lists it, the client SHOULD warn the user or refuse to proceed rather than silently falling back to a weaker algorithm.
+- **Servers MUST NOT remove algorithms that are still in active use.** Removing an algorithm from `algorithms` MUST NOT invalidate existing registrations (§4.1), but the server SHOULD NOT remove an algorithm unless it has a documented migration path for existing hosts and agents using it.
+
+### 8.17 Constraint Enforcement Atomicity
+
+Constraints (§2.13) are validated at the time the server processes the execution request (§5.11). However, the underlying data or state may change between validation and actual execution — a time-of-check/time-of-use (TOCTOU) gap. For example, a constraint of `max_amount: 1000` is checked against the request's `amount` field, but if the execution involves multiple steps, the effective amount could differ by the time the operation completes.
+
+This is an implementation concern, not a protocol-level issue — the protocol defines *what* constraints mean, not *how* the server executes operations internally. However, servers SHOULD be aware of the TOCTOU risk:
+
+- **Atomic validation.** Where possible, servers SHOULD validate constraints and execute the operation atomically (e.g. within a database transaction).
+- **Re-validation.** For multi-step or asynchronous operations, servers SHOULD re-validate constraints at each step that could violate them, not just at the initial request.
+- **Idempotency.** Servers SHOULD ensure that constraint-validated operations are idempotent where applicable, so that retries after partial failures do not bypass constraints.
+
+### 8.18 Cross-Server Capability Confusion
+
+Each agent JWT includes an `aud` claim set to the server's `issuer` URL (§4.3). This prevents a JWT intended for server A from being accepted by server B — the `aud` check in verification (§4.5 step 3) rejects it. However, this only works if both sides enforce `aud`:
+
+- **Servers MUST reject JWTs where `aud` does not exactly match their own `issuer` URL.** This is already required (§4.5 step 3) but is restated here for emphasis.
+- **Clients MUST set `aud` to the specific server's `issuer` URL for each request.** A client that sets `aud` to a wildcard or reuses JWTs across servers defeats this protection.
+- **Clients MUST NOT reuse a signed JWT across multiple servers.** Even if two servers happen to share a capability name (e.g. `send_email`), the JWT for one is not valid for the other.
 
 ## 9. Privacy Considerations
 

--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -623,12 +623,12 @@ Host-authenticated endpoints (`POST /agent/register`, `GET /agent/status`, `POST
 
 1. Verify the JWT header `typ` is `host+jwt` — reject if it is not
 2. Extract `iss` from JWT
-3. Look up the host:
+3. Verify `aud` matches the server's own `issuer` URL — reject if it doesn't
+4. Look up the host:
    - **By `iss`** — if a host with this identifier is found, use it.
    - **By `host_jwks_url`** (fallback) — if `iss` is not recognized but the JWT contains `host_jwks_url`, look up the host by that URL. If found, this is a key rotation: re-fetch the JWKS, locate the key matching the JWT header `kid`, verify its thumbprint matches `iss`, and update the stored host identifier.
    - **Unknown host** — if neither lookup finds a match, this is a dynamic registration. Extract the signing key from `host_public_key` (or fetch from `host_jwks_url` using the JWT header `kid`). Compute the JWK thumbprint (RFC 7638, SHA-256) and reject if it does not match `iss`.
-4. Verify JWT signature against the host's public key
-5. Verify `aud` matches the server's own `issuer` URL — reject if it doesn't
+5. Verify JWT signature against the host's public key
 6. Check `exp`, `iat` — reject if expired or issued in the future (see §8.2 for clock skew guidance)
 7. Check `jti` replay — reject if the `jti` has been seen within the JWT's lifetime window
 8. Check host status — reject if `revoked` or `rejected`. For `pending` hosts, only registration (§5.3) is allowed

--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -15,9 +15,9 @@ This document is an implementation-oriented comprehensive agent authentication a
 
 ### 1.1 Problem Statement
 
-AI agents are becoming long-lived actors: copilots, background workers, scheduled automations, and multi-step systems that call external services without constant human supervision. Today's auth models were not designed with this in mind. The problem framing falls into two categories.
+AI agents are becoming long-lived actors: copilots, background workers, scheduled automations, and multi-step systems that call external services without constant human supervision. Today's auth models were not designed with this in mind. The problem breaks down into three areas.
 
-1. Problems with agents acting on behalf of a user (Delegated agents)
+1. Agents acting on behalf of a user (Delegated agents)
 
 When an agent acts on behalf of a user, it typically reuses the user's OAuth token or a shared client credential. That collapses the runtime agent into someone else's identity:
 
@@ -25,9 +25,13 @@ When an agent acts on behalf of a user, it typically reuses the user's OAuth tok
 - **No scoping.** Every agent gets the user's full permissions or the client's permissions. You can't give one agent read-only access and another agent write access for a specific time period.
 - **No isolation.** You can't revoke one agent without revoking all of them. A compromised agent means rotating credentials for everything.
 
-2. Problems with agents operating autonomously (Autonomous agents)
+2. Agents operating without a human in the loop (Autonomous agents)
 
 Existing auth models tightly couple the human user and the application. When an agent needs to act on its own — without a user in the loop — there is no identity model for it. The agent is forced to pretend to be a human user: opening a browser, solving a CAPTCHA, and clicking through a signup flow just to use a service. There is no standard way for an agent to register itself, prove its identity, or receive capabilities without impersonating a person.
+
+3. Discovery
+
+There is no standard way for a service to advertise that it supports agents, what capabilities it offers, or how an agent should begin authenticating. Every new integration requires hardcoded configuration, prior training data, or a human pointing the agent to the right endpoint. Agents cannot arrive at an arbitrary service and programmatically orient themselves.
 
 ### 1.2 The Identity Problem
 
@@ -2581,11 +2585,11 @@ A separate revocation set (bloom filter, in-memory set, Redis) enables O(1) revo
 
 ### 10.3 Replay Detection Storage
 
-The `jti` replay cache does not need persistence. Replay detection only matters within the JWT's lifetime window (SHOULD be ≤60 seconds). An in-memory cache or probabilistic structure (bloom filter) with a TTL matching the JWT's max age is sufficient. The cache is partitioned by identity (agent ID or host ID) — see §4.6.
+The `jti` replay cache does not need persistence. Replay detection only matters within the effective validity window — the JWT's lifetime plus clock skew tolerance (see §8.2). With the default 60-second lifetime and 30-second skew, this is 90 seconds. An in-memory cache or probabilistic structure (bloom filter) with a TTL matching the effective window is sufficient. The cache is partitioned by identity (agent ID or host ID) — see §4.6.
 
 ### 10.4 JWKS Caching
 
-Servers that fetch JWKS URLs SHOULD cache the response and refresh periodically (recommended: every 5 minutes or on `kid` miss). Servers SHOULD handle JWKS URL unavailability gracefully — use previously cached keys and return a clear error if the URL is unreachable and no cached keys exist.
+Servers that fetch JWKS URLs SHOULD cache the response and refresh periodically (recommended: every 5 minutes or on `kid` miss). Servers SHOULD handle JWKS URL unavailability gracefully — use previously cached keys and return a clear error if the URL is unreachable and no cached keys exist. For JWKS content validation requirements (key type restrictions, key count limits, `kid` matching), see §8.12.
 
 ### 10.5 Client Key Storage
 

--- a/src/specs/v1.0-draft.mdx
+++ b/src/specs/v1.0-draft.mdx
@@ -512,10 +512,11 @@ Removing an algorithm from the discovery list MUST NOT invalidate existing agent
 
 ### 4.2 Host JWT
 
-Hosts authenticate by signing short-lived JWTs per [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) with the host's private key. The JWT header MUST include `kid` when using a JWKS URL.
+Hosts authenticate by signing short-lived JWTs per [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) with the host's private key. The JWT header MUST set `typ` to `host+jwt` and MUST include `kid` when using a JWKS URL. Servers MUST reject host-authenticated requests where the JWT `typ` is not `host+jwt`.
 
 | Claim | Type | Required | Description |
 |---|---|---|---|
+| `iss` | string | Yes | Host identifier. MUST be the JWK thumbprint ([RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638)) of the host's signing public key, computed using SHA-256. This is always the thumbprint of the key used to sign this JWT, regardless of whether the key is provided inline (`host_public_key`) or via JWKS (`host_jwks_url`). |
 | `aud` | string | Yes | Server's `issuer` URL from discovery. |
 | `iat` | number | Yes | Issued-at timestamp. |
 | `exp` | number | Yes | Expiration timestamp. |
@@ -526,10 +527,17 @@ Hosts authenticate by signing short-lived JWTs per [RFC 7519](https://datatracke
 | `agent_jwks_url` | string | Conditional | JWKS URL for the agent's public keys. Required for registration (§5.3) unless `agent_public_key` is provided. Not required on other endpoints. |
 | `agent_kid` | string | Conditional | Key ID for the agent's key in the agent JWKS. Required when `agent_jwks_url` is provided. |
 
+**Host identity and `iss` verification:**
+
+- **Inline-key hosts** (`host_public_key`): The server identifies the host by `iss` (the key's thumbprint). For known hosts, `iss` MUST match the stored identifier. Key rotation via §5.9 updates the stored identifier atomically.
+- **JWKS-based hosts** (`host_jwks_url`): The server identifies the host by the `host_jwks_url` value, which is stable across key rotations. The `iss` claim MUST still match the thumbprint of the signing key (identified by `kid` in the JWT header), but when the host rotates its signing key, `iss` changes. The server resolves this by looking up the host by `host_jwks_url`, then re-fetching the JWKS to discover the new key (see §8.7).
+- **New hosts** (registration): The server MUST compute the JWK thumbprint of the presented signing key and verify it matches `iss` — reject if they differ.
+
 **Example Host JWT payload (for registration):**
 
 ```json
 {
+  "iss": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
   "aud": "https://api.example.com",
   "iat": 1710000000,
   "exp": 1710000060,
@@ -543,10 +551,11 @@ Host and agent JWKS URLs MUST point to different endpoints. Servers that fetch J
 
 ### 4.3 Agent JWT
 
-Agents authenticate by signing short-lived JWTs per [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519). JWTs SHOULD expire within 60 seconds.
+Agents authenticate by signing short-lived JWTs per [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519). The JWT header MUST set `typ` to `agent+jwt`. JWTs SHOULD expire within 60 seconds. Servers MUST reject agent-authenticated requests where the JWT `typ` is not `agent+jwt`.
 
 | Claim | Type | Required | Description |
 |---|---|---|---|
+| `iss` | string | Yes | The host's identifier as known by this server — the JWK thumbprint of the host's current signing key (same value as the host JWT `iss`). Allows the server to resolve the agent's parent host without a database lookup on `sub` first. |
 | `sub` | string | Yes | Agent ID. |
 | `aud` | string | Yes | Server's `issuer` URL from discovery. |
 | `iat` | number | Yes | Issued-at timestamp. |
@@ -558,6 +567,7 @@ Agents authenticate by signing short-lived JWTs per [RFC 7519](https://datatrack
 
 ```json
 {
+  "iss": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
   "sub": "agt_k7x9m2",
   "aud": "https://api.example.com",
   "iat": 1710000000,
@@ -590,20 +600,41 @@ For higher-security deployments, servers MAY require a standard proof-of-possess
 
 ### 4.5 Verification
 
-1. Extract `sub` from JWT (agent ID)
-2. Verify `aud` matches the server's own `issuer` URL — reject if it doesn't
-3. Look up the agent by `sub`
-4. Look up the agent's host — reject if the host is revoked or pending
-5. Check agent status — reject if revoked, expired, or pending
-6. Verify JWT signature against the agent's stored public key (or JWKS)
-7. Check `exp`, `iat`, `jti` replay
-8. If proof of possession is required by server policy, validate the DPoP proof or mTLS binding and ensure it matches the JWT's `cnf` claim
-9. Resolve the agent's granted capabilities
-10. If `capabilities` claim is present in the JWT, intersect with granted capabilities — reject if the requested operation is not in the intersection
-11. If the matching grant carries `constraints` (§2.13), validate that the request arguments satisfy all constraints — reject with `constraint_violated` if any are violated
-12. Process the request
+1. Verify the JWT header `typ` is `agent+jwt` — reject if it is not (prevents token confusion with host JWTs)
+2. Extract `iss` and `sub` from JWT
+3. Verify `aud` matches the server's own `issuer` URL — reject if it doesn't
+4. Look up the host by `iss`. If not found, fall back to looking up the agent by `sub` first, then resolve its parent host — this handles the race window during JWKS key rotation where the agent uses the new `iss` before the server has updated the host's identifier (see §8.7). If the fallback was used, verify that `iss` corresponds to a valid key in the host's JWKS (the signature check in step 7 serves as this verification — if `iss` is not the thumbprint of the actual signing key, the signature will fail). Reject if the host is unknown, revoked, or pending.
+5. Look up the agent by `sub` — verify the agent belongs to the resolved host
+6. Check agent status — reject if revoked, expired, or pending
+7. Verify JWT signature against the agent's stored public key (or JWKS)
+8. Check `exp`, `iat`, `jti` replay
+9. If proof of possession is required by server policy, validate the DPoP proof or mTLS binding and ensure it matches the JWT's `cnf` claim
+10. Resolve the agent's granted capabilities
+11. If `capabilities` claim is present in the JWT, intersect with granted capabilities — reject if the requested operation is not in the intersection
+12. If the matching grant carries `constraints` (§2.13), validate that the request arguments satisfy all constraints — reject with `constraint_violated` if any are violated
+13. Process the request
 
 The server MUST ensure that revocation takes effect within a bounded window.
+
+### 4.5.1 Host JWT Verification
+
+Host-authenticated endpoints (`POST /agent/register`, `GET /agent/status`, `POST /agent/reactivate`, `POST /agent/revoke`, key rotation endpoints) MUST verify the host JWT as follows:
+
+1. Verify the JWT header `typ` is `host+jwt` — reject if it is not
+2. Extract `iss` from JWT
+3. Look up the host:
+   - **By `iss`** — if a host with this identifier is found, use it.
+   - **By `host_jwks_url`** (fallback) — if `iss` is not recognized but the JWT contains `host_jwks_url`, look up the host by that URL. If found, this is a key rotation: re-fetch the JWKS, locate the key matching the JWT header `kid`, verify its thumbprint matches `iss`, and update the stored host identifier.
+   - **Unknown host** — if neither lookup finds a match, this is a dynamic registration. Extract the signing key from `host_public_key` (or fetch from `host_jwks_url` using the JWT header `kid`). Compute the JWK thumbprint (RFC 7638, SHA-256) and reject if it does not match `iss`.
+4. Verify JWT signature against the host's public key
+5. Verify `aud` matches the server's own `issuer` URL — reject if it doesn't
+6. Check `exp`, `iat` — reject if expired or issued in the future (see §8.2 for clock skew guidance)
+7. Check `jti` replay — reject if the `jti` has been seen within the JWT's lifetime window
+8. Check host status — reject if `revoked` or `rejected`. For `pending` hosts, only registration (§5.3) is allowed
+9. If this is a registration request, extract the agent key claims (`agent_public_key` or `agent_jwks_url` + `agent_kid`) for agent creation
+10. Process the request
+
+For dynamic registration with an unknown host, the server MUST NOT trust the host identity until user approval completes (see §8.10).
 
 ### 4.6 Replay Detection
 
@@ -1549,7 +1580,9 @@ When capability execution is not complete yet, the server MUST return `202 Accep
 | `result` | any | Async result payload. Present when `status` is `"completed"`. |
 | `error` | object | Error details per §5.13. Present when the status is `"failed"`. |
 
-The `status_url` is polled until completion. Polling responses SHOULD use `200 OK` with the same async object shape and `status` set to `"pending"`, `"completed"`, or `"failed"`.
+The `status_url` is polled until completion. Polling requests MUST include an agent JWT in the `Authorization` header — the server MUST verify the JWT and confirm the requesting agent matches the agent that initiated the execution. Unauthenticated `status_url` endpoints are a security risk: anyone who discovers the URL could read execution results. Polling responses SHOULD use `200 OK` with the same async object shape and `status` set to `"pending"`, `"completed"`, or `"failed"`.
+
+Because agent JWTs are short-lived (SHOULD be ≤60 seconds per §8.2), the client MUST mint a fresh JWT for each polling request. For long-running operations, this means the client signs a new JWT on every poll cycle. This is by design — it ensures the server can enforce revocation checks on every poll rather than granting open-ended access through a long-lived token. Clients SHOULD use exponential backoff when polling (e.g. 1s, 2s, 4s, 8s up to a server-suggested maximum) to limit the number of JWTs minted.
 
 For streaming capabilities, the server returns a `200` response with `Content-Type: text/event-stream` and streams Server-Sent Events. The client SHOULD expose the stream to the agent when the transport supports it.
 
@@ -2181,6 +2214,16 @@ Each entry in `providers` is a standard discovery document (§5.1). The client M
 
 How services are added to a registry is implementation-specific. A registry MAY accept submissions via API, require manual review, auto-discover from a crawl, or any other mechanism. The only protocol requirement is the search interface above.
 
+**Registry integrity:**
+
+Registries are a trust anchor — a poisoned registry entry can direct agents to malicious servers. Registries and clients SHOULD apply the following protections:
+
+- **Issuer verification.** Before adding a service to the registry, the registry SHOULD fetch `{issuer}/.well-known/agent-configuration` and verify that the discovery document's `issuer` field matches the submitted `issuer` URL exactly. This prevents an attacker from registering a service entry pointing to someone else's domain.
+- **TLS validation.** The registry MUST fetch discovery documents over HTTPS and validate the server's TLS certificate chain. Reject self-signed or expired certificates.
+- **Periodic re-validation.** Registries SHOULD periodically re-fetch and re-validate listed services (e.g. daily). Services whose discovery endpoints become unreachable, return errors, or fail issuer verification SHOULD be flagged or delisted.
+- **Spam and squatting prevention.** Public registries SHOULD require verification of domain ownership before listing a service (e.g. DNS TXT record, well-known file challenge). This prevents attackers from registering entries for domains they do not control.
+- **Client-side verification.** Clients SHOULD verify the `issuer` field in the discovery document returned by a registry entry matches the `issuer` in the registry result. If they differ, the client MUST reject the entry and SHOULD warn the user.
+
 ## 7. Approval Methods
 
 When a registration or capability request requires user consent, the server returns an approval object describing how the client should facilitate it. This section defines the approval methods the protocol supports.
@@ -2251,9 +2294,13 @@ General guidance:
 
 Private keys MUST never be transmitted to or stored on the server. The server stores only public keys or JWKS URLs.
 
-### 8.2 JWT Lifetime
+### 8.2 JWT Lifetime and Clock Skew
 
 JWTs SHOULD expire within 60 seconds. Short lifetimes limit misuse even without proof of possession.
+
+Servers SHOULD allow a clock skew tolerance of no more than 30 seconds when validating `exp` and `iat` claims. Servers MUST NOT accept JWTs with an `iat` more than 30 seconds in the future. Servers SHOULD log and monitor clock-skew rejections — a high rate may indicate misconfigured clients or replay attempts rather than legitimate clock drift.
+
+**Effective validity window.** With a 60-second JWT lifetime and 30-second clock skew tolerance, the effective window during which a JWT may be accepted is up to 90 seconds (60s lifetime + 30s skew on `exp`). Implementers MUST size their `jti` replay caches to cover this full effective window — not just the nominal JWT lifetime — to prevent replay attacks in the skew margin. For tighter security, reduce either the JWT lifetime or the skew tolerance. A 30-second lifetime with 5-second skew (35-second effective window) is appropriate for low-latency environments.
 
 ### 8.3 Proof of Possession
 
@@ -2284,6 +2331,8 @@ Inline key hosts rotate via `POST /host/rotate-key` (§5.9). Since the client do
 
 JWKS-based hosts rotate by updating their endpoint — the server picks up new keys on the next cache refresh (recommended: every 5 minutes or on `kid` miss). The old key SHOULD remain in the JWKS for a grace period to avoid rejecting in-flight requests.
 
+Because `iss` is the JWK thumbprint of the signing key, JWKS key rotation changes the host's `iss` value. The server updates its stored host identifier when it processes a host JWT signed with the new key (§4.5.1 step 3). However, there is a race window: agent JWTs may arrive with the new `iss` before any host JWT has triggered the update. Servers MUST handle this by falling back to the agent's `sub` to resolve the parent host when `iss` is unrecognized (§4.5 step 4). Servers SHOULD also retain the previous host identifier for a grace period matching the JWKS cache TTL.
+
 Hosts that register across many servers SHOULD prefer JWKS-based registration, since key rotation propagates automatically without the client needing to contact each server individually.
 
 ### 8.8 Agent Key Compromise
@@ -2308,10 +2357,13 @@ Mitigations:
 - **Allowlists.** Clients MAY maintain an allowlist of trusted service URLs.
 - **Proof on host-authenticated registration.** For **discovered servers** (not pre-configured), clients SHOULD use DPoP or an equivalent request-specific proof on host-authenticated registration requests so they cannot be replayed to a different endpoint.
 - **TLS verification.** Clients MUST verify TLS certificates when fetching discovery endpoints.
+- **Registry integrity.** When using registry-based discovery, clients SHOULD verify that the `issuer` in the fetched discovery document matches the `issuer` from the registry result. A mismatch indicates a poisoned registry entry or a man-in-the-middle attack. See §6.11 for registry-side protections.
 
 ### 8.10 Approval Gravity
 
 User approval is the primary trust boundary in this protocol — for unknown host registration, capability escalation, and account linking.
+
+**Self-attestation during dynamic registration.** When a host registers for the first time, its JWT is self-signed — the public key is carried inside the JWT itself, and the server has never seen this host before. Anyone can create a valid host identity. The server MUST NOT grant any capabilities or trust the host identity until user approval completes. Until approval, the host and agent exist in `pending` state with no granted access. This is the designed trust model: the cryptographic identity is established immediately, but authorization is deferred entirely to the approval flow.
 
 First-time host approval is the highest-risk moment: the server knows nothing about the host beyond a self-signed keypair. Servers SHOULD present the requested capabilities clearly and warn if the host is requesting unusually broad access.
 
@@ -2358,6 +2410,16 @@ Both servers and clients fetch external URLs as part of the protocol. The threat
 
 For discovery-specific protections (allowlists, user confirmation, TLS verification), see §8.9.
 
+**JWKS content validation.** After fetching a JWKS document, servers and clients MUST validate its contents before using any keys:
+
+- The response MUST be valid JSON conforming to [RFC 7517 §5](https://datatracker.ietf.org/doc/html/rfc7517#section-5). Reject responses that do not parse as a JWK Set.
+- The `keys` array MUST contain at least one key. Reject empty key sets.
+- Each key MUST include `kty` and the required parameters for its key type. Reject keys with missing or unrecognized key type parameters.
+- Only asymmetric key types (`RSA`, `EC`, `OKP`) are permitted. Reject symmetric keys (`kty: "oct"`) — symmetric keys have no place in this protocol and their presence indicates a misconfiguration or attack.
+- If `kid` is expected (e.g. referenced in a JWT header), the set MUST contain a key with that `kid`. Reject if the expected key is not found.
+- Servers SHOULD limit the number of keys in a JWKS response (e.g. 20 keys). An attacker-controlled JWKS with many keys forces the server to attempt signature verification against each one.
+- Servers SHOULD cache JWKS responses per [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517) cache headers, with a maximum cache duration (e.g. 24 hours) and a minimum refresh interval (e.g. 5 minutes) to prevent cache-busting attacks.
+
 ### 8.13 Rate Limiting
 
 Servers MUST implement rate limiting. Agents can generate high request volumes — both legitimately and due to bugs or compromised keys.
@@ -2397,15 +2459,21 @@ The protocol relies on JWT signatures over TLS for authentication. For high-secu
 
 These are optional enhancements. The base protocol's security model (short-lived signed JWTs + TLS) is sufficient for most deployments. Proof of possession adds defense-in-depth for environments where token theft or replay is a realistic threat.
 
+### 8.15 Capability Name Squatting
+
+Capability names are server-defined strings and MUST be treated as opaque identifiers by clients. Because the server defines and controls its own capability namespace, capability name squatting (where an attacker pre-registers a capability name to hijack later requests) is not a protocol-level threat — the server is authoritative over its own names.
+
+However, if a server allows hosts to _suggest_ new capability names during registration (an extension behavior, not defined in this specification), the server MUST validate suggested names against its own namespace and reject conflicts. The risk in this scenario is a confused-deputy attack where a malicious host registers a capability name that collides with a legitimate one.
+
 ## 9. Privacy Considerations
 
 ### 9.1 Host Key Correlation
 
-A host uses the same keypair across all servers it connects to. This means two colluding servers can correlate activity: if `bank.com` and `shop.com` both see the same host public key, they know the same client is connecting to both. This is analogous to a browser fingerprint.
+A host uses the same keypair (or JWKS URL) across all servers it connects to. This means two colluding servers can correlate activity: if `bank.com` and `shop.com` both see the same host public key, they know the same client is connecting to both.
 
-Mitigations:
-- **Per-server host keys.** Clients MAY generate a separate host keypair for each server. This eliminates cross-server correlation at the cost of more keys to manage.
-- **JWKS rotation.** Hosts using JWKS URLs can rotate keys independently per server, but the JWKS URL itself is a stable identifier — rotating the URL too is necessary for full unlinkability.
+This is a deliberate design trade-off, not a vulnerability. A shared host identity enables host reputation — servers can build trust for a host based on its behavior over time, and future protocol extensions may allow servers to vouch for known hosts. It also keeps client implementation simple: one keypair, no per-server key management.
+
+Clients that require unlinkability across servers MAY generate a separate host keypair per server — either randomly or by deriving per-server keys from a single root secret using HKDF ([RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869)) with the server's `issuer` URL as context, avoiding the need to store one keypair per server. This is not expected to be common and is incompatible with JWKS-based host keys (where the URL itself is a stable cross-server identifier).
 
 ### 9.2 Agent Activity Tracking
 


### PR DESCRIPTION
## Summary

### JWT Identity Model
- Add `iss` claim to both host and agent JWTs — always the JWK thumbprint (RFC 7638, SHA-256) of the host's signing key
- Add `typ` header requirement: `host+jwt` for host JWTs, `agent+jwt` for agent JWTs (prevents token confusion)
- Add §4.5.1 Host JWT Verification — 10-step flow mirroring agent verification
- Define dual host identity model: inline hosts identified by `iss` (thumbprint), JWKS hosts identified by `host_jwks_url` (stable across rotations)
- Handle JWKS key rotation race window: agent verification falls back to `sub` lookup when `iss` is unrecognized

### Security Hardening
- **§8.2** Clock skew: 30s max tolerance, effective 90s window called out, replay caches must cover full window
- **§8.7** Key delivery mode locked at registration (inline ↔ JWKS switching blocked)
- **§8.8.1** Host key compromise: new dedicated section with threat model and recovery guidance
- **§8.10** Display-text injection: servers MUST sanitize `name`, `reason`, `host_name`, `binding_message` on approval screens
- **§8.12** JWKS content validation (asymmetric only, key count limits, caching). Server-returned URL validation (`status_url` origin check, `verification_uri` phishing protection)
- **§8.15** Capability name squatting (not a protocol threat; guidance for extensions)
- **§8.16** Discovery downgrade attacks (algorithm narrowing detection)
- **§8.17** Constraint enforcement atomicity (TOCTOU guidance)
- **§8.18** Cross-server capability confusion (`aud` enforcement restated)

### Other Changes
- **§5.11** `status_url` polling requires agent JWT auth; fresh JWT per poll; streaming JWT expiry lifecycle
- **§6.11** Registry integrity: issuer verification, domain ownership, periodic re-validation
- **§8.9** Algorithm downgrade protection, registry integrity cross-reference
- **§9.1** Host key correlation reframed as deliberate design trade-off (reputation > unlinkability)