### PR TITLE
fix: clarify approval error format uses message not error_description

### DIFF
--- a/content/specification/v1.0-draft.mdx
+++ b/content/specification/v1.0-draft.mdx
@@ -1841,7 +1841,7 @@ The error value is a machine-readable code (a snake_case string). The message va
 
 Servers MAY return additional error codes beyond those listed. Clients SHOULD handle unknown error codes gracefully by falling back to the HTTP status code.
 
-For device authorization endpoints (§7.1), error responses follow [RFC 8628 §3.5](https://datatracker.ietf.org/doc/html/rfc8628#section-3.5). For CIBA endpoints (§7.2), error responses follow [OpenID CIBA Core §13](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.13).
+Approval-related error codes from device authorization (e.g. `authorization_pending`, `slow_down`, `access_denied` per [RFC 8628 §3.5](https://datatracker.ietf.org/doc/html/rfc8628#section-3.5)) and CIBA (per [OpenID CIBA Core §13](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.13)) are used as the `error` value. The error format on all Agent Auth endpoints uses the standard shape defined above (`error` + `message`), not the OAuth `error_description` field.
 
 ### 5.14 Resource Server Challenge (Optional)
 


### PR DESCRIPTION
## Summary
- Clarified that device authorization (RFC 8628) and CIBA error **codes** (e.g. `authorization_pending`, `slow_down`, `access_denied`) are used as the `error` value, but the error **format** on all Agent Auth endpoints uses the standard `error` + `message` shape — not OAuth's `error_description` field.
- The previous wording ("error responses follow RFC 8628 §3.5 / CIBA Core §13") implied using the OAuth error response shape, which conflicted with Agent Auth's own error format defined in §5.13.
